### PR TITLE
Change java removals to C

### DIFF
--- a/pa3/pa3-check.sh
+++ b/pa3/pa3-check.sh
@@ -66,4 +66,4 @@ echo ""
 
 rm -f *out.txt
 
-rm -f *.class ModelDictionaryTest.java garbage*
+rm -f ModelDictionaryTest ModelDictionaryTest.c garbage*


### PR DESCRIPTION
Previously this was for a java course I'm guessing, this line is why the grading script leaves the two files "ModelDictionaryTest" and "ModelDictionaryTest.c" behind as it is still looking for the java files.